### PR TITLE
fix: crash when Add book dialog is rotated

### DIFF
--- a/app/src/main/java/software/mdev/bookstracker/ui/bookslist/dialogs/AddEditBookDialog.kt
+++ b/app/src/main/java/software/mdev/bookstracker/ui/bookslist/dialogs/AddEditBookDialog.kt
@@ -610,13 +610,13 @@ class AddEditBookDialog : DialogFragment() {
             object : AdapterView.OnItemSelectedListener {
                 override fun onItemSelected(
                     parent: AdapterView<*>,
-                    view: View,
+                    view: View?,
                     position: Int,
                     id: Long
                 ) {
-                    view.hideKeyboard()
+                    view?.hideKeyboard()
                     activity?.resources?.getColor(R.color.colorDefaultText)?.let {
-                        (parent.getChildAt(0) as TextView).setTextColor(
+                        (parent.getChildAt(0) as TextView?)?.setTextColor(
                             it
                         )
                     }


### PR DESCRIPTION
App crashes when Add/Edit book screen is rotated

This was the error
`java.lang.NullPointerException: Parameter specified as non-null is null: method kotlin.jvm.internal.Intrinsics.checkNotNullParameter, parameter view`

so added a null safety check to avoid crash