### PR TITLE
feat: change book status via context menu

### DIFF
--- a/app/src/main/java/software/mdev/bookstracker/adapters/BookAdapter.kt
+++ b/app/src/main/java/software/mdev/bookstracker/adapters/BookAdapter.kt
@@ -134,7 +134,7 @@ class BookAdapter(
             }
             setOnLongClickListener {
                 onBookLongClickListener?.let { it(curBook) }
-                true
+                onBookLongClickListener == null
             }
         }
     }

--- a/app/src/main/java/software/mdev/bookstracker/adapters/BookListAdapter.kt
+++ b/app/src/main/java/software/mdev/bookstracker/adapters/BookListAdapter.kt
@@ -2,6 +2,7 @@ package software.mdev.bookstracker.adapters
 
 import android.content.Context
 import android.os.Bundle
+import android.view.ContextMenu
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -36,9 +37,31 @@ class BookListAdapter(
 
 ) : RecyclerView.Adapter<BookListAdapter.BookListViewHolder>() {
 
-    inner class BookListViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView)
+    inner class BookListViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView), View.OnCreateContextMenuListener {
+        init {
+            itemView.setOnCreateContextMenuListener(this)
+        }
+        override fun onCreateContextMenu(
+            menu: ContextMenu?,
+            view: View?,
+            p2: ContextMenu.ContextMenuInfo?
+        ) {
+            when (adapterPosition) {
+                1 -> {
+                    menu?.add(R.string.menu_finished_reading_book)
+                }
+                2 -> {
+                    menu?.add(R.string.menu_start_reading_book)
+                    menu?.add(R.string.menu_finished_reading_book)
+                }
+            }
+        }
+    }
+
     lateinit var viewModel: BooksViewModel
     private val functions = Functions()
+    var selectedBook: Book? = null
+        private set
 
     private val differCallback = object : DiffUtil.ItemCallback<String>() {
         override fun areItemsTheSame(oldItem: String, newItem: String): Boolean {
@@ -111,7 +134,10 @@ class BookListAdapter(
             )
         }
 
+        booksFragment.registerForContextMenu(holder.itemView.rvBooks)
+
         bookAdapter.setOnBookLongClickListener {
+            selectedBook = it
         }
 
         // triggers after saving new sort mode

--- a/app/src/main/java/software/mdev/bookstracker/ui/bookslist/dialogs/AddEditBookDialog.kt
+++ b/app/src/main/java/software/mdev/bookstracker/ui/bookslist/dialogs/AddEditBookDialog.kt
@@ -53,6 +53,7 @@ import software.mdev.bookstracker.other.RoundCornersTransform
 import software.mdev.bookstracker.ui.bookslist.ListActivity
 import software.mdev.bookstracker.ui.bookslist.viewmodel.BooksViewModel
 import software.mdev.bookstracker.ui.bookslist.viewmodel.BooksViewModelProviderFactory
+import software.mdev.bookstracker.utils.DateTimeUtils.clearDateOfTime
 import java.io.ByteArrayOutputStream
 import java.text.Normalizer
 import java.text.SimpleDateFormat
@@ -904,27 +905,6 @@ class AddEditBookDialog : DialogFragment() {
         btnFinishDateSave.visibility = viewVisibility
         btnFinishDateClear.visibility = viewVisibility
         datePickerView.visibility = viewVisibility
-    }
-
-    private fun clearDateOfTime(orgDate: Long): Long {
-        var date = Calendar.getInstance()
-        date.timeInMillis = orgDate!!
-
-        var year = date.get(Calendar.YEAR)
-        var month = date.get(Calendar.MONTH)
-        var day = date.get(Calendar.DAY_OF_MONTH)
-
-        var dateWithoutTime = Calendar.getInstance()
-        dateWithoutTime.timeInMillis = 0L
-        dateWithoutTime.set(Calendar.YEAR, year)
-        dateWithoutTime.set(Calendar.MONTH, month)
-        dateWithoutTime.set(Calendar.DAY_OF_MONTH, day)
-        dateWithoutTime.set(Calendar.HOUR, 0)
-        dateWithoutTime.set(Calendar.MINUTE, 0)
-        dateWithoutTime.set(Calendar.SECOND, 0)
-        dateWithoutTime.set(Calendar.MILLISECOND, 0)
-
-        return dateWithoutTime.timeInMillis
     }
 
     private fun initConfig() {

--- a/app/src/main/java/software/mdev/bookstracker/utils/DateTimeUtils.kt
+++ b/app/src/main/java/software/mdev/bookstracker/utils/DateTimeUtils.kt
@@ -1,0 +1,27 @@
+package software.mdev.bookstracker.utils
+
+import java.util.*
+
+object DateTimeUtils {
+
+    fun clearDateOfTime(orgDate: Long): Long {
+        val date = Calendar.getInstance()
+        date.timeInMillis = orgDate
+
+        val year = date.get(Calendar.YEAR)
+        val month = date.get(Calendar.MONTH)
+        val day = date.get(Calendar.DAY_OF_MONTH)
+
+        val dateWithoutTime = Calendar.getInstance()
+        dateWithoutTime.timeInMillis = 0L
+        dateWithoutTime.set(Calendar.YEAR, year)
+        dateWithoutTime.set(Calendar.MONTH, month)
+        dateWithoutTime.set(Calendar.DAY_OF_MONTH, day)
+        dateWithoutTime.set(Calendar.HOUR, 0)
+        dateWithoutTime.set(Calendar.MINUTE, 0)
+        dateWithoutTime.set(Calendar.SECOND, 0)
+        dateWithoutTime.set(Calendar.MILLISECOND, 0)
+
+        return dateWithoutTime.timeInMillis
+    }
+}

--- a/app/src/main/res/layout/dialog_rating.xml
+++ b/app/src/main/res/layout/dialog_rating.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="20dp"
+    android:paddingStart="8dp"
+    android:paddingTop="8dp"
+    android:paddingEnd="8dp"
+    android:paddingBottom="16dp">
+
+
+        <me.zhanghai.android.materialratingbar.MaterialRatingBar
+            android:id="@+id/rbBookRating"
+            style="@style/Widget.MaterialRatingBar.RatingBar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -331,4 +331,6 @@
     <string name="showAsGridList">Show as grid / list</string>
     <string name="and">And</string>
     <string name="or">Or</string>
+    <string name="menu_start_reading_book">Start Reading</string>
+    <string name="menu_finished_reading_book">Finished Reading</string>
 </resources>


### PR DESCRIPTION
This PR adds menu on long press of book item in `In Progress` and `For Later` tabs to change the book status

For `For Later` tab, there are two options
1. Start Reading: Changes the book status to `In Progress` and set current date as start date
2. Finished Reading: Changes the book status to `Finished`, shows up a rating dialog and sets current date as finished date

For `In Progress` tab, there is only `Finished Reading` option
