### PR TITLE
Make reading time field editable

### DIFF
--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -34,7 +34,6 @@
     "start_reading": "Start",
     "rate_book": "Rate this book",
     "skip": "Skip",
-    "days": "days",
     "reading_time": "Reading time",
     "pages_uppercase": "Pages",
     "pages_lowercase": "pages",
@@ -234,7 +233,20 @@
     "choose_not_finished_shelf": "Choose a shelf with not finished books:",
     "import_successful": "Import successful",
     "ok": "OK",
-    "hours": "hours",
-    "minutes": "minutes",
-    "set_reading_time": "Set Reading Time"
+    "day": {
+        "one": "{} day",
+        "other": "{} days",
+        "title": "Days"
+    },
+    "hour": {
+        "one": "{} hour",
+        "other": "{} hours",
+        "title": "Hours"
+    },
+    "minute": {
+        "one": "{} minute",
+        "other": "{} minutes",
+        "title": "Minutes"
+    },
+    "set_custom_reading_time": "Set custom reading time"
 }

--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -232,5 +232,9 @@
     "export_csv_description_1": "Covers are not exported",
     "import_goodreads_csv": "Import Goodreads CSV",
     "choose_not_finished_shelf": "Choose a shelf with not finished books:",
-    "import_successful": "Import successful"
+    "import_successful": "Import successful",
+    "ok": "OK",
+    "hours": "hours",
+    "minutes": "minutes",
+    "set_reading_time": "Set Reading Time"
 }

--- a/lib/database/database_provider.dart
+++ b/lib/database/database_provider.dart
@@ -28,7 +28,7 @@ class DatabaseProvider {
 
     return await openDatabase(
       path,
-      version: 5,
+      version: 6,
       onCreate: (Database db, int version) async {
         await db.execute("CREATE TABLE booksTable ("
             "id INTEGER PRIMARY KEY AUTOINCREMENT, "
@@ -52,7 +52,8 @@ class DatabaseProvider {
             "notes TEXT, "
             "has_cover INTEGER, "
             "cover BLOB, "
-            "blur_hash TEXT "
+            "blur_hash TEXT, "
+            "reading_time INTEGER"
             ")");
       },
       onUpgrade: (Database db, int oldVersion, int newVersion) async {
@@ -61,16 +62,19 @@ class DatabaseProvider {
 
           switch (oldVersion) {
             case 1:
-              _updateBookDatabaseV1toV5(batch);
+              _updateBookDatabaseV1toV6(batch);
               break;
             case 2:
-              _updateBookDatabaseV2toV5(batch);
+              _updateBookDatabaseV2toV6(batch);
               break;
             case 3:
-              _updateBookDatabaseV3toV5(batch);
+              _updateBookDatabaseV3toV6(batch);
               break;
             case 4:
-              _updateBookDatabaseV4toV5(batch);
+              _updateBookDatabaseV4toV6(batch);
+              break;
+            case 5:
+              _updateBookDatabaseV5toV6(batch);
               break;
           }
 
@@ -102,34 +106,46 @@ class DatabaseProvider {
     "ALTER TABLE booksTable ADD notes TEXT",
   ];
 
-  void _updateBookDatabaseV1toV5(Batch batch) {
+  final migrationScriptsV6 = [
+    "ALTER TABLE booksTable ADD reading_time INTEGER",
+  ];
+
+  void _updateBookDatabaseV1toV6(Batch batch) {
     _executeBatch(
       batch,
       migrationScriptsV2 +
           migrationScriptsV3 +
           migrationScriptsV4 +
-          migrationScriptsV5,
+          migrationScriptsV5 +
+          migrationScriptsV6,
     );
   }
 
-  void _updateBookDatabaseV2toV5(Batch batch) {
+  void _updateBookDatabaseV2toV6(Batch batch) {
     _executeBatch(
       batch,
-      migrationScriptsV3 + migrationScriptsV4 + migrationScriptsV5,
+      migrationScriptsV3 + migrationScriptsV4 + migrationScriptsV5 + migrationScriptsV6
     );
   }
 
-  void _updateBookDatabaseV3toV5(Batch batch) {
+  void _updateBookDatabaseV3toV6(Batch batch) {
     _executeBatch(
       batch,
-      migrationScriptsV4 + migrationScriptsV5,
+      migrationScriptsV4 + migrationScriptsV5 + migrationScriptsV6
     );
   }
 
-  void _updateBookDatabaseV4toV5(Batch batch) {
+  void _updateBookDatabaseV4toV6(Batch batch) {
     _executeBatch(
       batch,
-      migrationScriptsV5,
+      migrationScriptsV5 + migrationScriptsV6
+    );
+  }
+
+  void _updateBookDatabaseV5toV6(Batch batch) {
+    _executeBatch(
+      batch,
+      migrationScriptsV6,
     );
   }
 }

--- a/lib/database/database_provider.dart
+++ b/lib/database/database_provider.dart
@@ -123,23 +123,20 @@ class DatabaseProvider {
 
   void _updateBookDatabaseV2toV6(Batch batch) {
     _executeBatch(
-      batch,
-      migrationScriptsV3 + migrationScriptsV4 + migrationScriptsV5 + migrationScriptsV6
-    );
+        batch,
+        migrationScriptsV3 +
+            migrationScriptsV4 +
+            migrationScriptsV5 +
+            migrationScriptsV6);
   }
 
   void _updateBookDatabaseV3toV6(Batch batch) {
     _executeBatch(
-      batch,
-      migrationScriptsV4 + migrationScriptsV5 + migrationScriptsV6
-    );
+        batch, migrationScriptsV4 + migrationScriptsV5 + migrationScriptsV6);
   }
 
   void _updateBookDatabaseV4toV6(Batch batch) {
-    _executeBatch(
-      batch,
-      migrationScriptsV5 + migrationScriptsV6
-    );
+    _executeBatch(batch, migrationScriptsV5 + migrationScriptsV6);
   }
 
   void _updateBookDatabaseV5toV6(Batch batch) {

--- a/lib/generated/locale_keys.g.dart
+++ b/lib/generated/locale_keys.g.dart
@@ -36,7 +36,6 @@ abstract class LocaleKeys {
   static const start_reading = 'start_reading';
   static const rate_book = 'rate_book';
   static const skip = 'skip';
-  static const days = 'days';
   static const reading_time = 'reading_time';
   static const pages_uppercase = 'pages_uppercase';
   static const pages_lowercase = 'pages_lowercase';
@@ -240,7 +239,11 @@ abstract class LocaleKeys {
   static const choose_not_finished_shelf = 'choose_not_finished_shelf';
   static const import_successful = 'import_successful';
   static const ok = 'ok';
-  static const hours = 'hours';
-  static const minutes = 'minutes';
-  static const set_reading_time = 'set_reading_time';
+  static const day_title = 'day.title';
+  static const day = 'day';
+  static const hour_title = 'hour.title';
+  static const hour = 'hour';
+  static const minute_title = 'minute.title';
+  static const minute = 'minute';
+  static const set_custom_reading_time = 'set_custom_reading_time';
 }

--- a/lib/generated/locale_keys.g.dart
+++ b/lib/generated/locale_keys.g.dart
@@ -243,5 +243,4 @@ abstract class LocaleKeys {
   static const hours = 'hours';
   static const minutes = 'minutes';
   static const set_reading_time = 'set_reading_time';
-
 }

--- a/lib/generated/locale_keys.g.dart
+++ b/lib/generated/locale_keys.g.dart
@@ -239,4 +239,9 @@ abstract class LocaleKeys {
   static const import_goodreads_csv = 'import_goodreads_csv';
   static const choose_not_finished_shelf = 'choose_not_finished_shelf';
   static const import_successful = 'import_successful';
+  static const ok = 'ok';
+  static const hours = 'hours';
+  static const minutes = 'minutes';
+  static const set_reading_time = 'set_reading_time';
+
 }

--- a/lib/logic/bloc/stats_bloc/stats_bloc.dart
+++ b/lib/logic/bloc/stats_bloc/stats_bloc.dart
@@ -130,27 +130,27 @@ class StatsBloc extends Bloc<StatsEvent, StatsState> {
 
   BookYearlyStat? _getSlowestReadBookInYear(List<Book> books, int? year) {
     int? slowestReadTimeInMs;
-    int? slowestReadTimeInDays;
     String? slowestReadBook;
 
     for (Book book in books) {
-      if (book.startDate != null && book.finishDate != null) {
+      int? readTimeInMs;
+      if (book.readingTime != null) {
+        readTimeInMs = book.readingTime!.milliSeconds;
+      } else if (book.startDate != null && book.finishDate != null) {
         final startDate = book.startDate!;
         final finishDate = book.finishDate!;
+        readTimeInMs = finishDate.difference(startDate).inMilliseconds;
+      } else {
+        continue;
+      }
+      if (slowestReadTimeInMs == null) {
+        slowestReadTimeInMs = readTimeInMs;
+        slowestReadBook = '${book.title} - ${book.author}';
+      }
 
-        final timeDifference = finishDate.difference(startDate);
-
-        if (slowestReadTimeInMs == null) {
-          slowestReadTimeInMs = timeDifference.inMilliseconds;
-          slowestReadTimeInDays = timeDifference.inDays;
-          slowestReadBook = '${book.title} - ${book.author}';
-        }
-
-        if (timeDifference.inMilliseconds > slowestReadTimeInMs) {
-          slowestReadTimeInMs = timeDifference.inMilliseconds;
-          slowestReadTimeInDays = timeDifference.inDays;
-          slowestReadBook = '${book.title} - ${book.author}';
-        }
+      if (readTimeInMs > slowestReadTimeInMs) {
+        slowestReadTimeInMs = readTimeInMs;
+        slowestReadBook = '${book.title} - ${book.author}';
       }
     }
 
@@ -159,7 +159,7 @@ class StatsBloc extends Bloc<StatsEvent, StatsState> {
     } else {
       return BookYearlyStat(
         title: slowestReadBook,
-        value: slowestReadTimeInDays.toString(),
+        value: ReadingTime.fromMilliSeconds(slowestReadTimeInMs).toString(),
         year: year,
       );
     }
@@ -202,27 +202,27 @@ class StatsBloc extends Bloc<StatsEvent, StatsState> {
 
   BookYearlyStat? _getFastestReadBookInYear(List<Book> books, int? year) {
     int? fastestReadTimeInMs;
-    int? fastestReadTimeInDays;
     String? fastestReadBook;
 
     for (Book book in books) {
-      if (book.startDate != null && book.finishDate != null) {
+      int? readTimeInMs;
+      if (book.readingTime != null) {
+        readTimeInMs = book.readingTime!.milliSeconds;
+      } else if (book.startDate != null && book.finishDate != null) {
         final startDate = book.startDate!;
         final finishDate = book.finishDate!;
+        readTimeInMs = finishDate.difference(startDate).inMilliseconds;
+      } else {
+        continue;
+      }
+      if (fastestReadTimeInMs == null) {
+        fastestReadTimeInMs = readTimeInMs;
+        fastestReadBook = '${book.title} - ${book.author}';
+      }
 
-        final timeDifference = finishDate.difference(startDate);
-
-        if (fastestReadTimeInMs == null) {
-          fastestReadTimeInMs = timeDifference.inMilliseconds;
-          fastestReadTimeInDays = timeDifference.inDays;
-          fastestReadBook = '${book.title} - ${book.author}';
-        }
-
-        if (timeDifference.inMilliseconds < fastestReadTimeInMs) {
-          fastestReadTimeInMs = timeDifference.inMilliseconds;
-          fastestReadTimeInDays = timeDifference.inDays;
-          fastestReadBook = '${book.title} - ${book.author}';
-        }
+      if (readTimeInMs < fastestReadTimeInMs) {
+        fastestReadTimeInMs = readTimeInMs;
+        fastestReadBook = '${book.title} - ${book.author}';
       }
     }
 
@@ -231,7 +231,7 @@ class StatsBloc extends Bloc<StatsEvent, StatsState> {
     } else {
       return BookYearlyStat(
         title: fastestReadBook,
-        value: fastestReadTimeInDays.toString(),
+        value: ReadingTime.fromMilliSeconds(fastestReadTimeInMs).toString(),
         year: year,
       );
     }
@@ -390,7 +390,7 @@ class StatsBloc extends Bloc<StatsEvent, StatsState> {
 
     for (Book book in books) {
       if (book.readingTime != null) {
-        readTimeInMilliSeconds += book.readingTime!.timeInMilliSeconds;
+        readTimeInMilliSeconds += book.readingTime!.milliSeconds;
         countedBooks += 1;
         continue;
       }

--- a/lib/logic/bloc/stats_bloc/stats_bloc.dart
+++ b/lib/logic/bloc/stats_bloc/stats_bloc.dart
@@ -364,7 +364,7 @@ class StatsBloc extends Bloc<StatsEvent, StatsState> {
     for (var year in years) {
       final booksInyear = List<Book>.empty(growable: true);
       for (Book book in books) {
-        if ((book.finishDate != null || book.readingTime != null) && book.rating != null) {
+        if ((book.finishDate != null) && book.rating != null) {
           final finishYear = book.finishDate!.year;
 
           if (finishYear == year) {
@@ -397,7 +397,7 @@ class StatsBloc extends Bloc<StatsEvent, StatsState> {
       if (book.startDate != null && book.finishDate != null) {
         final startDate = book.startDate!;
         final finishDate = book.finishDate!;
-        final timeDifference = finishDate.difference(startDate).inMicroseconds;
+        final timeDifference = finishDate.difference(startDate).inMilliseconds;
 
         readTimeInMilliSeconds += timeDifference;
         countedBooks += 1;

--- a/lib/logic/cubit/edit_book_cubit.dart
+++ b/lib/logic/cubit/edit_book_cubit.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openreads/core/constants/enums.dart';
 import 'package:openreads/main.dart';
 import 'package:openreads/model/book.dart';
+import 'package:openreads/model/reading_time.dart';
 
 class EditBookCubit extends Cubit<Book> {
   EditBookCubit() : super(Book.empty());
@@ -130,6 +131,12 @@ class EditBookCubit extends Cubit<Book> {
     final book = state.copyWith();
     book.hasCover = hasCover;
 
+    emit(book);
+  }
+
+  void setReadingTime(ReadingTime? readingTime) {
+    final book = state.copyWith();
+    book.readingTime = readingTime;
     emit(book);
   }
 

--- a/lib/model/book.dart
+++ b/lib/model/book.dart
@@ -103,10 +103,11 @@ class Book {
         bookType: json['book_type'] == 'audiobook'
             ? BookType.audiobook
             : json['book_type'] == 'ebook'
-            ? BookType.ebook
-            : BookType.paper,
-        readingTime: json['reading_time'] != null ? ReadingTime.fromMilliSeconds(json['reading_time']): null
-    );
+                ? BookType.ebook
+                : BookType.paper,
+        readingTime: json['reading_time'] != null
+            ? ReadingTime.fromMilliSeconds(json['reading_time'])
+            : null);
   }
 
   Book copyWith({

--- a/lib/model/book.dart
+++ b/lib/model/book.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:openreads/core/constants/enums.dart';
 import 'package:openreads/main.dart';
 import 'package:openreads/model/book_from_backup_v3.dart';
+import 'package:openreads/model/reading_time.dart';
 
 class Book {
   int? id;
@@ -29,6 +30,7 @@ class Book {
   String? blurHash;
   BookType bookType;
   bool hasCover;
+  ReadingTime? readingTime;
 
   Book({
     this.id,
@@ -53,6 +55,7 @@ class Book {
     this.blurHash,
     this.bookType = BookType.paper,
     this.hasCover = false,
+    this.readingTime,
   });
 
   factory Book.empty() {
@@ -70,38 +73,39 @@ class Book {
 
   factory Book.fromJSON(Map<String, dynamic> json) {
     return Book(
-      id: json['id'],
-      title: json['title'],
-      subtitle: json['subtitle'],
-      author: json['author'],
-      description: json['description'],
-      status: json['status'],
-      rating: json['rating'],
-      favourite: (json['favourite'] == 1) ? true : false,
-      hasCover: (json['has_cover'] == 1) ? true : false,
-      deleted: (json['deleted'] == 1) ? true : false,
-      startDate: json['start_date'] != null
-          ? DateTime.parse(json['start_date'])
-          : null,
-      finishDate: json['finish_date'] != null
-          ? DateTime.parse(json['finish_date'])
-          : null,
-      pages: json['pages'],
-      publicationYear: json['publication_year'],
-      isbn: json['isbn'],
-      olid: json['olid'],
-      tags: json['tags'],
-      myReview: json['my_review'],
-      notes: json['notes'],
-      cover: json['cover'] != null
-          ? Uint8List.fromList(json['cover'].cast<int>().toList())
-          : null,
-      blurHash: json['blur_hash'],
-      bookType: json['book_type'] == 'audiobook'
-          ? BookType.audiobook
-          : json['book_type'] == 'ebook'
-              ? BookType.ebook
-              : BookType.paper,
+        id: json['id'],
+        title: json['title'],
+        subtitle: json['subtitle'],
+        author: json['author'],
+        description: json['description'],
+        status: json['status'],
+        rating: json['rating'],
+        favourite: (json['favourite'] == 1) ? true : false,
+        hasCover: (json['has_cover'] == 1) ? true : false,
+        deleted: (json['deleted'] == 1) ? true : false,
+        startDate: json['start_date'] != null
+            ? DateTime.parse(json['start_date'])
+            : null,
+        finishDate: json['finish_date'] != null
+            ? DateTime.parse(json['finish_date'])
+            : null,
+        pages: json['pages'],
+        publicationYear: json['publication_year'],
+        isbn: json['isbn'],
+        olid: json['olid'],
+        tags: json['tags'],
+        myReview: json['my_review'],
+        notes: json['notes'],
+        cover: json['cover'] != null
+            ? Uint8List.fromList(json['cover'].cast<int>().toList())
+            : null,
+        blurHash: json['blur_hash'],
+        bookType: json['book_type'] == 'audiobook'
+            ? BookType.audiobook
+            : json['book_type'] == 'ebook'
+            ? BookType.ebook
+            : BookType.paper,
+        readingTime: json['reading_time'] != null ? ReadingTime.fromMilliSeconds(json['reading_time']): null
     );
   }
 
@@ -127,6 +131,7 @@ class Book {
     String? blurHash,
     BookType? bookType,
     bool? hasCover,
+    ReadingTime? readingTime,
   }) {
     return Book(
       id: id,
@@ -151,6 +156,7 @@ class Book {
       blurHash: blurHash ?? this.blurHash,
       bookType: bookType ?? this.bookType,
       hasCover: hasCover ?? this.hasCover,
+      readingTime: readingTime ?? this.readingTime,
     );
   }
 
@@ -178,6 +184,7 @@ class Book {
       blurHash: blurHash,
       bookType: bookType,
       hasCover: hasCover,
+      readingTime: readingTime,
     );
   }
 
@@ -253,6 +260,7 @@ class Book {
           : bookType == BookType.ebook
               ? 'ebook'
               : 'paper',
+      'reading_time': readingTime?.timeInMilliSeconds,
     };
   }
 

--- a/lib/model/book.dart
+++ b/lib/model/book.dart
@@ -261,7 +261,7 @@ class Book {
           : bookType == BookType.ebook
               ? 'ebook'
               : 'paper',
-      'reading_time': readingTime?.timeInMilliSeconds,
+      'reading_time': readingTime?.milliSeconds,
     };
   }
 

--- a/lib/model/reading_time.dart
+++ b/lib/model/reading_time.dart
@@ -1,15 +1,17 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:openreads/generated/locale_keys.g.dart';
 
+// Converts milliseconds to days, hours, minutes to exactly what has been set.
+// This is needed because built-in DateTime returns the whole duration either in days or hours but not both
 class ReadingTime {
   int days;
   int hours;
   int minutes;
 
-  int timeInMilliSeconds;
+  int milliSeconds;
 
   ReadingTime(
-      {required this.timeInMilliSeconds,
+      {required this.milliSeconds,
       required this.days,
       required this.minutes,
       required this.hours});
@@ -25,16 +27,13 @@ class ReadingTime {
     int minutes = timeInSeconds ~/ 60;
 
     return ReadingTime(
-        timeInMilliSeconds: milliSeconds,
-        days: days,
-        minutes: minutes,
-        hours: hours);
+        milliSeconds: milliSeconds, days: days, minutes: minutes, hours: hours);
   }
 
   factory ReadingTime.toMilliSeconds(int days, hours, minutes) {
     int seconds = ((days * 86400) + (hours * 3600) + (minutes * 60)).toInt();
     return ReadingTime(
-        timeInMilliSeconds: seconds * 1000,
+        milliSeconds: seconds * 1000,
         days: days,
         minutes: minutes,
         hours: hours);
@@ -44,13 +43,13 @@ class ReadingTime {
   String toString() {
     String result = "";
     if (days != 0) {
-      result += "$days ${LocaleKeys.days.tr()}";
+      result += LocaleKeys.day.plural(days).tr();
     }
     if (hours != 0) {
-      result += " $hours ${LocaleKeys.hours.tr()}";
+      result += " ${LocaleKeys.hour.plural(hours).tr()}";
     }
     if (minutes != 0) {
-      result += " $minutes ${LocaleKeys.minutes.tr()}";
+      result += " ${LocaleKeys.minute.plural(minutes).tr()}";
     }
     return result;
   }

--- a/lib/model/reading_time.dart
+++ b/lib/model/reading_time.dart
@@ -1,0 +1,53 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:openreads/generated/locale_keys.g.dart';
+
+class ReadingTime {
+  int days;
+  int hours;
+  int minutes;
+
+  int timeInMilliSeconds;
+
+  ReadingTime({
+    required this.timeInMilliSeconds,
+    required this.days,
+    required this.minutes,
+    required this.hours
+});
+
+  factory ReadingTime.fromMilliSeconds(int milliSeconds) {
+    int timeInSeconds = milliSeconds ~/ 1000;
+    int days = timeInSeconds ~/ (24 * 3600);
+
+    timeInSeconds = timeInSeconds % (24 * 3600);
+    int hours = timeInSeconds ~/ 3600;
+
+    timeInSeconds %= 3600;
+    int minutes = timeInSeconds ~/ 60;
+
+
+    return ReadingTime(timeInMilliSeconds: milliSeconds, days: days, minutes: minutes, hours: hours);
+  }
+
+  factory ReadingTime.toMilliSeconds(int days, hours, minutes) {
+    int seconds = ((days * 86400) + (hours * 3600) + (minutes * 60)).toInt();
+    return ReadingTime(timeInMilliSeconds: seconds * 1000, days: days, minutes: minutes, hours: hours);
+  }
+
+
+  @override
+  String toString() {
+    String result = "";
+    if (days != 0) {
+      result += "$days ${LocaleKeys.days.tr()}";
+    }
+    if (hours != 0) {
+      result += " $hours ${LocaleKeys.hours.tr()}";
+    }
+    if (minutes != 0) {
+      result += " $minutes ${LocaleKeys.minutes.tr()}";
+    }
+    return result;
+  }
+
+}

--- a/lib/model/reading_time.dart
+++ b/lib/model/reading_time.dart
@@ -8,12 +8,11 @@ class ReadingTime {
 
   int timeInMilliSeconds;
 
-  ReadingTime({
-    required this.timeInMilliSeconds,
-    required this.days,
-    required this.minutes,
-    required this.hours
-});
+  ReadingTime(
+      {required this.timeInMilliSeconds,
+      required this.days,
+      required this.minutes,
+      required this.hours});
 
   factory ReadingTime.fromMilliSeconds(int milliSeconds) {
     int timeInSeconds = milliSeconds ~/ 1000;
@@ -25,15 +24,21 @@ class ReadingTime {
     timeInSeconds %= 3600;
     int minutes = timeInSeconds ~/ 60;
 
-
-    return ReadingTime(timeInMilliSeconds: milliSeconds, days: days, minutes: minutes, hours: hours);
+    return ReadingTime(
+        timeInMilliSeconds: milliSeconds,
+        days: days,
+        minutes: minutes,
+        hours: hours);
   }
 
   factory ReadingTime.toMilliSeconds(int days, hours, minutes) {
     int seconds = ((days * 86400) + (hours * 3600) + (minutes * 60)).toInt();
-    return ReadingTime(timeInMilliSeconds: seconds * 1000, days: days, minutes: minutes, hours: hours);
+    return ReadingTime(
+        timeInMilliSeconds: seconds * 1000,
+        days: days,
+        minutes: minutes,
+        hours: hours);
   }
-
 
   @override
   String toString() {
@@ -49,5 +54,4 @@ class ReadingTime {
     }
     return result;
   }
-
 }

--- a/lib/ui/add_book_screen/add_book_screen.dart
+++ b/lib/ui/add_book_screen/add_book_screen.dart
@@ -17,6 +17,7 @@ import 'package:openreads/resources/open_library_service.dart';
 import 'package:openreads/main.dart';
 import 'package:openreads/model/book.dart';
 import 'package:openreads/ui/add_book_screen/widgets/cover_view_edit.dart';
+import 'package:openreads/ui/add_book_screen/widgets/reading_time_field.dart';
 import 'package:openreads/ui/add_book_screen/widgets/widgets.dart';
 
 class AddBookScreen extends StatefulWidget {
@@ -441,6 +442,7 @@ class _AddBookScreenState extends State<AddBookScreen> {
               clearStartDate: _clearStartDate,
               clearFinishDate: _clearFinishDate,
             ),
+            const BookReadingTimeField(defaultHeight: defaultFormHeight),
             const Padding(
               padding: EdgeInsets.all(10),
               child: Divider(),

--- a/lib/ui/add_book_screen/widgets/reading_time_field.dart
+++ b/lib/ui/add_book_screen/widgets/reading_time_field.dart
@@ -147,73 +147,74 @@ class _BookReadingTimeField extends State<BookReadingTimeField> {
     return state.status != 0
         ? const SizedBox()
         : Column(children: [
-      const SizedBox(height: 10),
-      SizedBox(
-        height: widget.defaultHeight,
-        width: MediaQuery.of(context).size.width - 20,
-        child: Stack(
-          children: [
-            InkWell(
-              customBorder: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(cornerRadius),
-              ),
-              onTap: () => buildShowDialog(context),
-              child: Ink(
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(cornerRadius),
-                  color: Theme.of(context)
-                      .colorScheme
-                      .surfaceVariant
-                      .withOpacity(0.5),
-                  border: Border.all(color: dividerColor),
-                ),
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 10,
-                    vertical: 10,
-                  ),
-                  child: Center(
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.start,
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: [
-                        Icon(
-                          FontAwesomeIcons.solidClock,
-                          color: Theme.of(context).colorScheme.primary,
+            const SizedBox(height: 10),
+            SizedBox(
+              height: widget.defaultHeight,
+              width: MediaQuery.of(context).size.width - 20,
+              child: Stack(
+                children: [
+                  InkWell(
+                    customBorder: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(cornerRadius),
+                    ),
+                    onTap: () => buildShowDialog(context),
+                    child: Ink(
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(cornerRadius),
+                        color: Theme.of(context)
+                            .colorScheme
+                            .surfaceVariant
+                            .withOpacity(0.5),
+                        border: Border.all(color: dividerColor),
+                      ),
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 10,
+                          vertical: 10,
                         ),
-                        const SizedBox(width: 15),
-                        FittedBox(
-                          child: Text(
-                            formattedText,
-                            maxLines: 1,
-                            style: const TextStyle(fontSize: 14),
+                        child: Center(
+                          child: Row(
+                            mainAxisAlignment: MainAxisAlignment.start,
+                            crossAxisAlignment: CrossAxisAlignment.center,
+                            children: [
+                              Icon(
+                                FontAwesomeIcons.solidClock,
+                                color: Theme.of(context).colorScheme.primary,
+                              ),
+                              const SizedBox(width: 15),
+                              FittedBox(
+                                child: Text(
+                                  formattedText,
+                                  maxLines: 1,
+                                  style: const TextStyle(fontSize: 14),
+                                ),
+                              ),
+                            ],
                           ),
                         ),
+                      ),
+                    ),
+                  ),
+                  Center(
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        (state.readingTime != null)
+                            ? IconButton(
+                                icon: const Icon(
+                                  Icons.close,
+                                  size: 20,
+                                ),
+                                onPressed: _resetTime,
+                              )
+                            : const SizedBox(),
                       ],
                     ),
                   ),
-                ),
-              ),
-            ),
-            Center(
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.end,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  (state.readingTime != null)
-                      ? IconButton(
-                    icon: const Icon(
-                      Icons.close,
-                      size: 20,
-                    ),
-                    onPressed: _resetTime,
-                  ) : const SizedBox(),
                 ],
               ),
-            ),
-          ],
-        ),
-      )
-    ]);
+            )
+          ]);
   }
 }

--- a/lib/ui/add_book_screen/widgets/reading_time_field.dart
+++ b/lib/ui/add_book_screen/widgets/reading_time_field.dart
@@ -1,7 +1,6 @@
-import 'dart:ui';
-
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:openreads/core/themes/app_theme.dart';
@@ -47,12 +46,13 @@ class _BookReadingTimeField extends State<BookReadingTimeField> {
     return showDialog<String>(
         context: context,
         builder: (BuildContext context) => AlertDialog(
-            title: Text(LocaleKeys.set_reading_time.tr()),
+            title: Text(LocaleKeys.set_custom_reading_time.tr(),
+                style: const TextStyle(fontSize: 20)),
             contentPadding: const EdgeInsets.symmetric(vertical: 25),
             actions: <Widget>[
               TextButton(
                 onPressed: () => Navigator.pop(context, 'Cancel'),
-                child: const Text(LocaleKeys.cancel),
+                child: Text(LocaleKeys.cancel.tr()),
               ),
               TextButton(
                 onPressed: _changeReadingTime,
@@ -67,14 +67,14 @@ class _BookReadingTimeField extends State<BookReadingTimeField> {
                   SizedBox(
                       width: 70,
                       child: TextField(
-                        selectionWidthStyle: BoxWidthStyle.tight,
-                        autofocus: false,
+                        inputFormatters: <TextInputFormatter>[
+                          FilteringTextInputFormatter.digitsOnly
+                        ],
                         keyboardType: TextInputType.number,
                         controller: _day,
-                        maxLines: 1,
                         maxLength: 5,
                         decoration: InputDecoration(
-                          labelText: LocaleKeys.days.tr(),
+                          labelText: LocaleKeys.day_title.tr(),
                           border: const OutlineInputBorder(),
                           counterText: "",
                         ),
@@ -82,14 +82,15 @@ class _BookReadingTimeField extends State<BookReadingTimeField> {
                   SizedBox(
                       width: 70,
                       child: TextField(
-                        selectionWidthStyle: BoxWidthStyle.tight,
                         autofocus: true,
                         keyboardType: TextInputType.number,
                         controller: _hours,
-                        maxLines: 1,
+                        inputFormatters: <TextInputFormatter>[
+                          FilteringTextInputFormatter.digitsOnly
+                        ],
                         maxLength: 2,
                         decoration: InputDecoration(
-                          labelText: LocaleKeys.hours.tr(),
+                          labelText: LocaleKeys.hour_title.tr(),
                           border: const OutlineInputBorder(),
                           counterText: "",
                         ),
@@ -97,14 +98,14 @@ class _BookReadingTimeField extends State<BookReadingTimeField> {
                   SizedBox(
                     width: 70,
                     child: TextField(
-                      selectionWidthStyle: BoxWidthStyle.tight,
-                      autofocus: false,
                       keyboardType: TextInputType.number,
                       controller: _minutes,
-                      maxLines: 1,
+                      inputFormatters: <TextInputFormatter>[
+                        FilteringTextInputFormatter.digitsOnly
+                      ],
                       maxLength: 2,
                       decoration: InputDecoration(
-                        labelText: LocaleKeys.minutes.tr(),
+                        labelText: LocaleKeys.minute_title.tr(),
                         border: const OutlineInputBorder(),
                         counterText: "",
                       ),
@@ -142,7 +143,7 @@ class _BookReadingTimeField extends State<BookReadingTimeField> {
   Widget buildReadingTimeTextField(BuildContext context, Book state) {
     String formattedText = state.readingTime != null
         ? state.readingTime.toString()
-        : LocaleKeys.reading_time.tr();
+        : LocaleKeys.set_custom_reading_time.tr();
     _setTextControllers(state.readingTime);
     return state.status != 0
         ? const SizedBox()

--- a/lib/ui/add_book_screen/widgets/reading_time_field.dart
+++ b/lib/ui/add_book_screen/widgets/reading_time_field.dart
@@ -1,0 +1,219 @@
+import 'dart:ui';
+
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:openreads/core/themes/app_theme.dart';
+import 'package:openreads/generated/locale_keys.g.dart';
+import 'package:openreads/logic/cubit/edit_book_cubit.dart';
+import 'package:openreads/model/book.dart';
+import 'package:openreads/model/reading_time.dart';
+
+class BookReadingTimeField extends StatefulWidget {
+  const BookReadingTimeField({
+    Key? key,
+    required this.defaultHeight,
+  }) : super(key: key);
+
+  final double defaultHeight;
+
+  @override
+  State<BookReadingTimeField> createState() => _BookReadingTimeField();
+}
+
+class _BookReadingTimeField extends State<BookReadingTimeField> {
+  final _day = TextEditingController();
+  final _hours = TextEditingController();
+  final _minutes = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<EditBookCubit, Book>(builder: (context, state) {
+      return buildReadingTimeTextField(context, state);
+    });
+  }
+
+  @override
+  void dispose() {
+    _day.dispose();
+    _minutes.dispose();
+    _hours.dispose();
+
+    super.dispose();
+  }
+
+  Future<String?> buildShowDialog(BuildContext context) {
+    return showDialog<String>(
+        context: context,
+        builder: (BuildContext context) => AlertDialog(
+            title: Text(LocaleKeys.set_reading_time.tr()),
+            contentPadding: const EdgeInsets.symmetric(vertical: 25),
+            actions: <Widget>[
+              TextButton(
+                onPressed: () => Navigator.pop(context, 'Cancel'),
+                child: const Text(LocaleKeys.cancel),
+              ),
+              TextButton(
+                onPressed: _changeReadingTime,
+                child: Text(LocaleKeys.ok.tr()),
+              ),
+            ],
+            content: SizedBox(
+              width: MediaQuery.of(context).size.width,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  SizedBox(
+                      width: 70,
+                      child: TextField(
+                        selectionWidthStyle: BoxWidthStyle.tight,
+                        autofocus: false,
+                        keyboardType: TextInputType.number,
+                        controller: _day,
+                        maxLines: 1,
+                        maxLength: 5,
+                        decoration: InputDecoration(
+                          labelText: LocaleKeys.days.tr(),
+                          border: const OutlineInputBorder(),
+                          counterText: "",
+                        ),
+                      )),
+                  SizedBox(
+                      width: 70,
+                      child: TextField(
+                        selectionWidthStyle: BoxWidthStyle.tight,
+                        autofocus: true,
+                        keyboardType: TextInputType.number,
+                        controller: _hours,
+                        maxLines: 1,
+                        maxLength: 2,
+                        decoration: InputDecoration(
+                          labelText: LocaleKeys.hours.tr(),
+                          border: const OutlineInputBorder(),
+                          counterText: "",
+                        ),
+                      )),
+                  SizedBox(
+                    width: 70,
+                    child: TextField(
+                      selectionWidthStyle: BoxWidthStyle.tight,
+                      autofocus: false,
+                      keyboardType: TextInputType.number,
+                      controller: _minutes,
+                      maxLines: 1,
+                      maxLength: 2,
+                      decoration: InputDecoration(
+                        labelText: LocaleKeys.minutes.tr(),
+                        border: const OutlineInputBorder(),
+                        counterText: "",
+                      ),
+                    ),
+                  )
+                ],
+              ),
+            )));
+  }
+
+  void _changeReadingTime() {
+    int days = int.tryParse(_day.value.text) ?? 0;
+    int hours = int.tryParse(_hours.value.text) ?? 0;
+    int mins = int.tryParse(_minutes.value.text) ?? 0;
+    context
+        .read<EditBookCubit>()
+        .setReadingTime(ReadingTime.toMilliSeconds(days, hours, mins));
+    Navigator.pop(context, 'OK');
+  }
+
+  void _setTextControllers(ReadingTime? readingTime) {
+    if (readingTime == null) return;
+    _day.text = readingTime.days.toString();
+    _hours.text = readingTime.hours.toString();
+    _minutes.text = readingTime.minutes.toString();
+  }
+
+  void _resetTime() {
+    _day.clear();
+    _hours.clear();
+    _minutes.clear();
+    context.read<EditBookCubit>().setReadingTime(null);
+  }
+
+  Widget buildReadingTimeTextField(BuildContext context, Book state) {
+    String formattedText = state.readingTime != null
+        ? state.readingTime.toString()
+        : LocaleKeys.reading_time.tr();
+    _setTextControllers(state.readingTime);
+    return state.status != 0
+        ? const SizedBox()
+        : Column(children: [
+      const SizedBox(height: 10),
+      SizedBox(
+        height: widget.defaultHeight,
+        width: MediaQuery.of(context).size.width - 20,
+        child: Stack(
+          children: [
+            InkWell(
+              customBorder: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(cornerRadius),
+              ),
+              onTap: () => buildShowDialog(context),
+              child: Ink(
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(cornerRadius),
+                  color: Theme.of(context)
+                      .colorScheme
+                      .surfaceVariant
+                      .withOpacity(0.5),
+                  border: Border.all(color: dividerColor),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 10,
+                    vertical: 10,
+                  ),
+                  child: Center(
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.start,
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        Icon(
+                          FontAwesomeIcons.solidClock,
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
+                        const SizedBox(width: 15),
+                        FittedBox(
+                          child: Text(
+                            formattedText,
+                            maxLines: 1,
+                            style: const TextStyle(fontSize: 14),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            Center(
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  (state.readingTime != null)
+                      ? IconButton(
+                    icon: const Icon(
+                      Icons.close,
+                      size: 20,
+                    ),
+                    onPressed: _resetTime,
+                  ) : const SizedBox(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      )
+    ]);
+  }
+}

--- a/lib/ui/book_screen/book_screen.dart
+++ b/lib/ui/book_screen/book_screen.dart
@@ -155,9 +155,9 @@ class BookScreen extends StatelessWidget {
     ReadingTime? readingTime,
   }) {
     if (readingTime != null) return readingTime.toString();
-    final diff = finishDate!.difference(startDate!).inDays.toString();
+    final diff = finishDate!.difference(startDate!).inDays;
 
-    return '$diff ${LocaleKeys.days.tr()}';
+    return LocaleKeys.day.plural(diff).tr();
   }
 
   @override

--- a/lib/ui/book_screen/book_screen.dart
+++ b/lib/ui/book_screen/book_screen.dart
@@ -7,6 +7,7 @@ import 'package:openreads/logic/cubit/current_book_cubit.dart';
 import 'package:openreads/main.dart';
 import 'package:openreads/model/book.dart';
 import 'package:openreads/ui/book_screen/widgets/widgets.dart';
+import 'package:openreads/model/reading_time.dart';
 
 class BookScreen extends StatelessWidget {
   const BookScreen({
@@ -148,11 +149,13 @@ class BookScreen extends StatelessWidget {
   }
 
   String _generateReadingTime({
-    required DateTime startDate,
-    required DateTime finishDate,
+    DateTime? startDate,
+    DateTime? finishDate,
     required BuildContext context,
+    ReadingTime? readingTime,
   }) {
-    final diff = finishDate.difference(startDate).inDays.toString();
+    if (readingTime != null) return readingTime.toString();
+    final diff = finishDate!.difference(startDate!).inDays.toString();
 
     return '$diff ${LocaleKeys.days.tr()}';
   }
@@ -166,6 +169,8 @@ class BookScreen extends StatelessWidget {
       appBar: const BookScreenAppBar(),
       body: BlocBuilder<CurrentBookCubit, Book>(
         builder: (context, state) {
+          var showReadingTime = ((state.finishDate != null && state.startDate != null)
+              || state.readingTime != null);
           return SingleChildScrollView(
             child: Column(
               children: [
@@ -228,12 +233,13 @@ class BookScreen extends StatelessWidget {
                             ? 5
                             : 0,
                       ),
-                      (state.finishDate != null && state.startDate != null)
+                      (showReadingTime)
                           ? BookDetail(
                               title: LocaleKeys.reading_time.tr(),
                               text: _generateReadingTime(
-                                finishDate: state.finishDate!,
-                                startDate: state.startDate!,
+                                finishDate: state.finishDate,
+                                startDate: state.startDate,
+                                readingTime: state.readingTime,
                                 context: context,
                               ),
                             )

--- a/lib/ui/book_screen/book_screen.dart
+++ b/lib/ui/book_screen/book_screen.dart
@@ -169,8 +169,9 @@ class BookScreen extends StatelessWidget {
       appBar: const BookScreenAppBar(),
       body: BlocBuilder<CurrentBookCubit, Book>(
         builder: (context, state) {
-          var showReadingTime = ((state.finishDate != null && state.startDate != null)
-              || state.readingTime != null);
+          var showReadingTime =
+              ((state.finishDate != null && state.startDate != null) ||
+                  state.readingTime != null);
           return SingleChildScrollView(
             child: Column(
               children: [

--- a/lib/ui/statistics_screen/widgets/statistics.dart
+++ b/lib/ui/statistics_screen/widgets/statistics.dart
@@ -482,7 +482,7 @@ class Statistics extends StatelessWidget {
         return ReadStats(
           title: LocaleKeys.average_reading_time.tr(),
           value: (bookYearlyStat.value != '')
-              ? '${bookYearlyStat.value} ${LocaleKeys.days.tr()}'
+              ? '${bookYearlyStat.value}'
               : '0',
         );
       }

--- a/lib/ui/statistics_screen/widgets/statistics.dart
+++ b/lib/ui/statistics_screen/widgets/statistics.dart
@@ -481,9 +481,7 @@ class Statistics extends StatelessWidget {
       if (bookYearlyStat.year == year) {
         return ReadStats(
           title: LocaleKeys.average_reading_time.tr(),
-          value: (bookYearlyStat.value != '')
-              ? '${bookYearlyStat.value}'
-              : '0',
+          value: (bookYearlyStat.value != '') ? '${bookYearlyStat.value}' : '0',
         );
       }
     }

--- a/lib/ui/statistics_screen/widgets/statistics.dart
+++ b/lib/ui/statistics_screen/widgets/statistics.dart
@@ -538,7 +538,7 @@ class Statistics extends StatelessWidget {
         return ReadStats(
           title: LocaleKeys.fastest_book.tr(),
           value: bookYearlyStat.title.toString(),
-          secondValue: '${bookYearlyStat.value} ${LocaleKeys.days.tr()}',
+          secondValue: bookYearlyStat.value,
         );
       }
     }
@@ -556,7 +556,7 @@ class Statistics extends StatelessWidget {
         return ReadStats(
           title: LocaleKeys.slowest_book.tr(),
           value: bookYearlyStat.title.toString(),
-          secondValue: '${bookYearlyStat.value} ${LocaleKeys.days.tr()}',
+          secondValue: bookYearlyStat.value,
         );
       }
     }


### PR DESCRIPTION
Currently reading time field is only readable, this PR adds a reading time field in the Add/Edit book screen which will be visible only if the status is finished. If reading time is not edited or set then the default logic of reading time (calculated based on start and finish dates) will be used.