### PR TITLE
Additional reading dates

### DIFF
--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -276,5 +276,7 @@
     "download_missing_covers_explanation": "Download missing covers for books that have ISBN set",
     "downloaded_covers": "Downloaded covers:",
     "try_downloading_covers": "Do you want to try downloading missing covers for imported books?",
-    "filter_out_selected_tags": "Filter out selected tags"
+    "filter_out_selected_tags": "Filter out selected tags",
+    "add_additional_reading_time": "Add additional reading time",
+    "additional_reading": "Additional reading:"
 }

--- a/lib/database/database_provider.dart
+++ b/lib/database/database_provider.dart
@@ -30,7 +30,7 @@ class DatabaseProvider {
 
     return await openDatabase(
       path,
-      version: 6,
+      version: 7,
       onCreate: (Database db, int version) async {
         await db.execute("CREATE TABLE booksTable ("
             "id INTEGER PRIMARY KEY AUTOINCREMENT, "
@@ -55,7 +55,8 @@ class DatabaseProvider {
             "has_cover INTEGER, "
             "cover BLOB, "
             "blur_hash TEXT, "
-            "reading_time INTEGER"
+            "reading_time INTEGER, "
+            "additional_readings TEXT"
             ")");
       },
       onUpgrade: (Database db, int oldVersion, int newVersion) async {
@@ -64,19 +65,22 @@ class DatabaseProvider {
 
           switch (oldVersion) {
             case 1:
-              _updateBookDatabaseV1toV6(batch);
+              _updateBookDatabaseV1toV7(batch);
               break;
             case 2:
-              _updateBookDatabaseV2toV6(batch);
+              _updateBookDatabaseV2toV7(batch);
               break;
             case 3:
-              _updateBookDatabaseV3toV6(batch);
+              _updateBookDatabaseV3toV7(batch);
               break;
             case 4:
-              _updateBookDatabaseV4toV6(batch);
+              _updateBookDatabaseV4toV7(batch);
               break;
             case 5:
-              _updateBookDatabaseV5toV6(batch);
+              _updateBookDatabaseV5toV7(batch);
+              break;
+            case 6:
+              _updateBookDatabaseV6toV7(batch);
               break;
           }
 
@@ -112,39 +116,61 @@ class DatabaseProvider {
     "ALTER TABLE booksTable ADD reading_time INTEGER",
   ];
 
-  void _updateBookDatabaseV1toV6(Batch batch) {
+  final migrationScriptsV7 = [
+    "ALTER TABLE booksTable ADD additional_readings TEXT",
+  ];
+
+  void _updateBookDatabaseV1toV7(Batch batch) {
     _executeBatch(
       batch,
       migrationScriptsV2 +
           migrationScriptsV3 +
           migrationScriptsV4 +
           migrationScriptsV5 +
-          migrationScriptsV6,
+          migrationScriptsV6 +
+          migrationScriptsV7,
     );
   }
 
-  void _updateBookDatabaseV2toV6(Batch batch) {
-    _executeBatch(
-        batch,
-        migrationScriptsV3 +
-            migrationScriptsV4 +
-            migrationScriptsV5 +
-            migrationScriptsV6);
-  }
-
-  void _updateBookDatabaseV3toV6(Batch batch) {
-    _executeBatch(
-        batch, migrationScriptsV4 + migrationScriptsV5 + migrationScriptsV6);
-  }
-
-  void _updateBookDatabaseV4toV6(Batch batch) {
-    _executeBatch(batch, migrationScriptsV5 + migrationScriptsV6);
-  }
-
-  void _updateBookDatabaseV5toV6(Batch batch) {
+  void _updateBookDatabaseV2toV7(Batch batch) {
     _executeBatch(
       batch,
-      migrationScriptsV6,
+      migrationScriptsV3 +
+          migrationScriptsV4 +
+          migrationScriptsV5 +
+          migrationScriptsV6 +
+          migrationScriptsV7,
+    );
+  }
+
+  void _updateBookDatabaseV3toV7(Batch batch) {
+    _executeBatch(
+      batch,
+      migrationScriptsV4 +
+          migrationScriptsV5 +
+          migrationScriptsV6 +
+          migrationScriptsV7,
+    );
+  }
+
+  void _updateBookDatabaseV4toV7(Batch batch) {
+    _executeBatch(
+      batch,
+      migrationScriptsV5 + migrationScriptsV6 + migrationScriptsV7,
+    );
+  }
+
+  void _updateBookDatabaseV5toV7(Batch batch) {
+    _executeBatch(
+      batch,
+      migrationScriptsV6 + migrationScriptsV7,
+    );
+  }
+
+  void _updateBookDatabaseV6toV7(Batch batch) {
+    _executeBatch(
+      batch,
+      migrationScriptsV7,
     );
   }
 }

--- a/lib/generated/locale_keys.g.dart
+++ b/lib/generated/locale_keys.g.dart
@@ -273,4 +273,6 @@ abstract class LocaleKeys {
   static const downloaded_covers = 'downloaded_covers';
   static const try_downloading_covers = 'try_downloading_covers';
   static const filter_out_selected_tags = 'filter_out_selected_tags';
+  static const add_additional_reading_time = 'add_additional_reading_time';
+  static const additional_reading = 'additional_reading';
 }

--- a/lib/logic/cubit/edit_book_cubit.dart
+++ b/lib/logic/cubit/edit_book_cubit.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openreads/core/constants/enums.dart';
 import 'package:openreads/main.dart';
+import 'package:openreads/model/additional_reading.dart';
 import 'package:openreads/model/book.dart';
 import 'package:openreads/model/reading_time.dart';
 
@@ -168,6 +169,61 @@ class EditBookCubit extends Cubit<Book> {
 
     final book = state.copyWith();
     book.tags = tags.isEmpty ? null : tags.join('|||||');
+
+    emit(book);
+  }
+
+  void addNewAdditionalReading(AdditionalReading additionalReading) {
+    List<AdditionalReading> additionalReadings = state.additionalReadings ?? [];
+
+    additionalReadings.add(additionalReading);
+
+    final book = state.copyWith();
+    book.additionalReadings = additionalReadings;
+
+    emit(book);
+  }
+
+  void removeAdditionalReading(int index) {
+    List<AdditionalReading> additionalReadings = state.additionalReadings ?? [];
+
+    additionalReadings.removeAt(index);
+
+    final book = state.copyWith();
+    book.additionalReadings = additionalReadings;
+
+    emit(book);
+  }
+
+  void setAdditionalStartDate(DateTime? startDate, int index) {
+    List<AdditionalReading> additionalReadings = state.additionalReadings ?? [];
+
+    additionalReadings[index].startDate = startDate;
+
+    final book = state.copyWith();
+    book.additionalReadings = additionalReadings;
+
+    emit(book);
+  }
+
+  setAdditionalFinishDate(DateTime? finishDate, int index) {
+    List<AdditionalReading> additionalReadings = state.additionalReadings ?? [];
+
+    additionalReadings[index].finishDate = finishDate;
+
+    final book = state.copyWith();
+    book.additionalReadings = additionalReadings;
+
+    emit(book);
+  }
+
+  setAdditionalReadingTime(ReadingTime? readingTime, int index) {
+    List<AdditionalReading> additionalReadings = state.additionalReadings ?? [];
+
+    additionalReadings[index].customReadingTime = readingTime;
+
+    final book = state.copyWith();
+    book.additionalReadings = additionalReadings;
 
     emit(book);
   }

--- a/lib/model/additional_reading.dart
+++ b/lib/model/additional_reading.dart
@@ -1,0 +1,46 @@
+import 'package:openreads/model/reading_time.dart';
+
+class AdditionalReading {
+  DateTime? startDate;
+  DateTime? finishDate;
+  ReadingTime? customReadingTime;
+
+  AdditionalReading({
+    this.startDate,
+    this.finishDate,
+    this.customReadingTime,
+  });
+
+  factory AdditionalReading.fromString(String input) {
+    List<String> dateAndValue = input.split('|');
+
+    DateTime? startDate =
+        dateAndValue[0] != '' ? DateTime.parse(dateAndValue[0]) : null;
+    DateTime? finishDate =
+        dateAndValue[1] != '' ? DateTime.parse(dateAndValue[1]) : null;
+    final customReadingTime = dateAndValue[2] != ''
+        ? ReadingTime.fromMilliSeconds(
+            int.parse(dateAndValue[2]),
+          )
+        : null;
+
+    return AdditionalReading(
+      startDate: startDate,
+      finishDate: finishDate,
+      customReadingTime: customReadingTime,
+    );
+  }
+
+  @override
+  String toString() {
+    final startDate =
+        this.startDate != null ? this.startDate!.toIso8601String() : '';
+    final finishDate =
+        this.finishDate != null ? this.finishDate!.toIso8601String() : '';
+    final customReadingTime = this.customReadingTime != null
+        ? this.customReadingTime!.milliSeconds.toString()
+        : '';
+
+    return '$startDate|$finishDate|$customReadingTime';
+  }
+}

--- a/lib/model/book.dart
+++ b/lib/model/book.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:openreads/core/constants/enums.dart';
 import 'package:openreads/main.dart';
+import 'package:openreads/model/additional_reading.dart';
 import 'package:openreads/model/book_from_backup_v3.dart';
 import 'package:openreads/model/reading_time.dart';
 
@@ -31,6 +32,7 @@ class Book {
   BookFormat bookFormat;
   bool hasCover;
   ReadingTime? readingTime;
+  List<AdditionalReading>? additionalReadings;
 
   Book({
     this.id,
@@ -56,6 +58,7 @@ class Book {
     this.bookFormat = BookFormat.paperback,
     this.hasCover = false,
     this.readingTime,
+    this.additionalReadings,
   });
 
   factory Book.empty() {
@@ -112,33 +115,38 @@ class Book {
       readingTime: json['reading_time'] != null
           ? ReadingTime.fromMilliSeconds(json['reading_time'])
           : null,
+      additionalReadings: json['additional_readings'] != null
+          ? List<AdditionalReading>.from(json['additional_readings']
+              .map((x) => AdditionalReading.fromString(x)))
+          : null,
     );
   }
 
-  Book copyWith({
-    String? title,
-    String? author,
-    int? status,
-    String? subtitle,
-    String? description,
-    bool? favourite,
-    bool? deleted,
-    int? rating,
-    DateTime? startDate,
-    DateTime? finishDate,
-    int? pages,
-    int? publicationYear,
-    String? isbn,
-    String? olid,
-    String? tags,
-    String? myReview,
-    String? notes,
-    Uint8List? cover,
-    String? blurHash,
-    BookFormat? bookFormat,
-    bool? hasCover,
-    ReadingTime? readingTime,
-  }) {
+  Book copyWith(
+      {String? title,
+      String? author,
+      int? status,
+      String? subtitle,
+      String? description,
+      bool? favourite,
+      bool? deleted,
+      int? rating,
+      DateTime? startDate,
+      DateTime? finishDate,
+      int? pages,
+      int? publicationYear,
+      String? isbn,
+      String? olid,
+      String? tags,
+      String? myReview,
+      String? notes,
+      Uint8List? cover,
+      String? blurHash,
+      BookFormat? bookFormat,
+      bool? hasCover,
+      ReadingTime? readingTime,
+      List<AdditionalReading>? additionalReadings,
+      x}) {
     return Book(
       id: id,
       title: title ?? this.title,
@@ -163,6 +171,7 @@ class Book {
       bookFormat: bookFormat ?? this.bookFormat,
       hasCover: hasCover ?? this.hasCover,
       readingTime: readingTime ?? this.readingTime,
+      additionalReadings: additionalReadings ?? this.additionalReadings,
     );
   }
 
@@ -191,6 +200,7 @@ class Book {
       bookFormat: bookFormat,
       hasCover: hasCover,
       readingTime: readingTime,
+      additionalReadings: additionalReadings,
     );
   }
 
@@ -271,6 +281,8 @@ class Book {
                       ? 'paperback'
                       : 'paperback',
       'reading_time': readingTime?.milliSeconds,
+      'additional_readings':
+          additionalReadings?.map((x) => x.toString()).toList(),
     };
   }
 

--- a/lib/model/book.dart
+++ b/lib/model/book.dart
@@ -116,8 +116,9 @@ class Book {
           ? ReadingTime.fromMilliSeconds(json['reading_time'])
           : null,
       additionalReadings: json['additional_readings'] != null
-          ? List<AdditionalReading>.from(json['additional_readings']
-              .map((x) => AdditionalReading.fromString(x)))
+          ? jsonDecode(json['additional_readings'])
+              .map<AdditionalReading>((e) => AdditionalReading.fromString(e))
+              .toList()
           : null,
     );
   }
@@ -281,8 +282,9 @@ class Book {
                       ? 'paperback'
                       : 'paperback',
       'reading_time': readingTime?.milliSeconds,
-      'additional_readings':
-          additionalReadings?.map((x) => x.toString()).toList(),
+      'additional_readings': additionalReadings != null
+          ? jsonEncode(additionalReadings!.map((e) => e.toString()).toList())
+          : null,
     };
   }
 

--- a/lib/ui/add_book_screen/add_book_screen.dart
+++ b/lib/ui/add_book_screen/add_book_screen.dart
@@ -489,7 +489,7 @@ class _AddBookScreenState extends State<AddBookScreen> {
               ),
               BlocBuilder<EditBookCubit, Book>(
                 builder: (context, state) {
-                  if (state.additionalReadings == null &&
+                  if (state.additionalReadings == null ||
                       state.additionalReadings!.isEmpty) {
                     return const SizedBox();
                   }

--- a/lib/ui/add_book_screen/widgets/additional_reading_row.dart
+++ b/lib/ui/add_book_screen/widgets/additional_reading_row.dart
@@ -1,0 +1,202 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:openreads/core/constants/constants.dart';
+import 'package:openreads/core/themes/app_theme.dart';
+import 'package:openreads/generated/locale_keys.g.dart';
+import 'package:openreads/logic/cubit/edit_book_cubit.dart';
+import 'package:openreads/model/additional_reading.dart';
+import 'package:openreads/model/reading_time.dart';
+import 'package:openreads/ui/add_book_screen/widgets/reading_time_field.dart';
+import 'package:openreads/ui/add_book_screen/widgets/widgets.dart';
+
+class AdditionalReadingRow extends StatefulWidget {
+  const AdditionalReadingRow({
+    super.key,
+    required this.index,
+    required this.reading,
+  });
+
+  final int index;
+  final AdditionalReading reading;
+
+  @override
+  State<AdditionalReadingRow> createState() => _AdditionalReadingRowState();
+}
+
+class _AdditionalReadingRowState extends State<AdditionalReadingRow> {
+  void _showStartDatePicker() async {
+    FocusManager.instance.primaryFocus?.unfocus();
+
+    final startDate = await showDatePicker(
+      context: context,
+      // if startDate is null, use DateTime.now()
+      initialDate: widget.reading.startDate ?? DateTime.now(),
+      firstDate: DateTime(1970),
+      lastDate: DateTime.now(),
+      helpText: LocaleKeys.select_start_date.tr(),
+    );
+
+    if (mounted && startDate != null) {
+      context.read<EditBookCubit>().setAdditionalStartDate(
+            startDate,
+            widget.index,
+          );
+    }
+  }
+
+  void _showFinishDatePicker() async {
+    FocusManager.instance.primaryFocus?.unfocus();
+
+    final finishDate = await showDatePicker(
+      context: context,
+      // if finishDate is null, use DateTime.now()
+      initialDate: widget.reading.finishDate ?? DateTime.now(),
+
+      firstDate: DateTime(1970),
+      lastDate: DateTime.now(),
+      helpText: LocaleKeys.select_finish_date.tr(),
+    );
+
+    if (mounted && finishDate != null) {
+      context.read<EditBookCubit>().setAdditionalFinishDate(
+            finishDate,
+            widget.index,
+          );
+    }
+  }
+
+  void _clearStartDate() {
+    context.read<EditBookCubit>().setAdditionalStartDate(null, widget.index);
+  }
+
+  void _clearFinishDate() {
+    context.read<EditBookCubit>().setAdditionalFinishDate(null, widget.index);
+  }
+
+  void _changeReadingTime(
+    String daysString,
+    String hoursString,
+    String minutesString,
+  ) {
+    int days = int.tryParse(daysString) ?? 0;
+    int hours = int.tryParse(hoursString) ?? 0;
+    int mins = int.tryParse(minutesString) ?? 0;
+
+    context.read<EditBookCubit>().setAdditionalReadingTime(
+          ReadingTime.toMilliSeconds(days, hours, mins),
+          widget.index,
+        );
+
+    Navigator.pop(context, 'OK');
+  }
+
+  void _resetTime() {
+    context.read<EditBookCubit>().setAdditionalReadingTime(null, widget.index);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final dateFormat = DateFormat.yMd(
+      '${context.locale.languageCode}-${context.locale.countryCode}',
+    );
+
+    return Container(
+      padding: const EdgeInsets.fromLTRB(0, 10, 10, 10),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              children: [
+                Row(
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(10, 0, 10, 0),
+                      child: Text(
+                        LocaleKeys.additional_reading.tr(),
+                        style: const TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 10),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(20, 0, 10, 0),
+                  child: Container(
+                    clipBehavior: Clip.hardEdge,
+                    decoration: const BoxDecoration(),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: SetDateButton(
+                            defaultHeight: defaultFormHeight,
+                            icon: FontAwesomeIcons.play,
+                            text: widget.reading.startDate != null
+                                ? dateFormat.format(widget.reading.startDate!)
+                                : LocaleKeys.start_date.tr(),
+                            onPressed: _showStartDatePicker,
+                            onClearPressed: _clearStartDate,
+                            showClearButton: (widget.reading.startDate != null)
+                                ? true
+                                : false,
+                          ),
+                        ),
+                        const SizedBox(width: 10),
+                        Expanded(
+                          child: SetDateButton(
+                            defaultHeight: defaultFormHeight,
+                            icon: FontAwesomeIcons.flagCheckered,
+                            text: widget.reading.finishDate != null
+                                ? dateFormat.format(widget.reading.finishDate!)
+                                : LocaleKeys.finish_date.tr(),
+                            onPressed: _showFinishDatePicker,
+                            onClearPressed: _clearFinishDate,
+                            showClearButton: (widget.reading.finishDate != null)
+                                ? true
+                                : false,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(left: 10),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    children: [
+                      Expanded(
+                        child: BookReadingTimeField(
+                          defaultHeight: defaultFormHeight,
+                          changeReadingTime: _changeReadingTime,
+                          resetTime: _resetTime,
+                          readingTime: widget.reading.customReadingTime,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          FilledButton.tonal(
+            onPressed: () {
+              context
+                  .read<EditBookCubit>()
+                  .removeAdditionalReading(widget.index);
+            },
+            style: ButtonStyle(
+              shape: MaterialStateProperty.all(
+                RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(cornerRadius),
+                ),
+              ),
+            ),
+            child: const Icon(Icons.remove),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/add_book_screen/widgets/set_date_button.dart
+++ b/lib/ui/add_book_screen/widgets/set_date_button.dart
@@ -3,14 +3,14 @@ import 'package:openreads/core/themes/app_theme.dart';
 
 class SetDateButton extends StatelessWidget {
   const SetDateButton({
-    Key? key,
+    super.key,
     required this.defaultHeight,
     required this.icon,
     required this.text,
     required this.onPressed,
     required this.onClearPressed,
     required this.showClearButton,
-  }) : super(key: key);
+  });
 
   final double defaultHeight;
   final IconData icon;
@@ -53,12 +53,12 @@ class SetDateButton extends StatelessWidget {
                         icon,
                         color: Theme.of(context).colorScheme.primary,
                       ),
-                      const SizedBox(width: 15),
+                      const SizedBox(width: 10),
                       FittedBox(
                         child: Text(
                           text,
                           maxLines: 1,
-                          style: const TextStyle(fontSize: 14),
+                          style: const TextStyle(fontSize: 12),
                         ),
                       ),
                     ],

--- a/lib/ui/add_book_screen/widgets/widgets.dart
+++ b/lib/ui/add_book_screen/widgets/widgets.dart
@@ -7,3 +7,4 @@ export 'date_row.dart';
 export 'book_rating_bar.dart';
 export 'tags_text_field.dart';
 export 'book_type_dropdown.dart';
+export 'additional_reading_row.dart';

--- a/lib/ui/book_screen/book_screen.dart
+++ b/lib/ui/book_screen/book_screen.dart
@@ -7,14 +7,13 @@ import 'package:openreads/logic/cubit/current_book_cubit.dart';
 import 'package:openreads/main.dart';
 import 'package:openreads/model/book.dart';
 import 'package:openreads/ui/book_screen/widgets/widgets.dart';
-import 'package:openreads/model/reading_time.dart';
 
 class BookScreen extends StatelessWidget {
   const BookScreen({
-    Key? key,
+    super.key,
     required this.id,
     required this.heroTag,
-  }) : super(key: key);
+  });
 
   final int id;
   final String heroTag;
@@ -141,19 +140,6 @@ class BookScreen extends StatelessWidget {
     context.read<CurrentBookCubit>().setBook(book);
   }
 
-  String _generateReadingTime({
-    DateTime? startDate,
-    DateTime? finishDate,
-    required BuildContext context,
-    ReadingTime? readingTime,
-  }) {
-    if (readingTime != null) return readingTime.toString();
-    final diff = finishDate!.difference(startDate!).inDays +
-        1; // should be at least 1 day
-
-    return LocaleKeys.day.plural(diff).tr();
-  }
-
   @override
   Widget build(BuildContext context) {
     final mediaQuery = MediaQuery.of(context);
@@ -163,9 +149,6 @@ class BookScreen extends StatelessWidget {
       appBar: const BookScreenAppBar(),
       body: BlocBuilder<CurrentBookCubit, Book>(
         builder: (context, state) {
-          var showReadingTime =
-              ((state.finishDate != null && state.startDate != null) ||
-                  state.readingTime != null);
           return SingleChildScrollView(
             child: Column(
               children: [
@@ -196,16 +179,13 @@ class BookScreen extends StatelessWidget {
                       ),
                       const SizedBox(height: 5),
                       BookStatusDetail(
+                        book: state,
                         statusIcon: _decideStatusIcon(state.status),
                         statusText: _decideStatusText(
                           state.status,
                           context,
                         ),
-                        rating: state.rating,
-                        startDate: state.startDate,
-                        finishDate: state.finishDate,
                         onLikeTap: () => _onLikeTap(context, state),
-                        isLiked: state.favourite,
                         showChangeStatus: (state.status == 1 ||
                             state.status == 2 ||
                             state.status == 3),
@@ -228,17 +208,6 @@ class BookScreen extends StatelessWidget {
                             ? 5
                             : 0,
                       ),
-                      (showReadingTime)
-                          ? BookDetail(
-                              title: LocaleKeys.reading_time.tr(),
-                              text: _generateReadingTime(
-                                finishDate: state.finishDate,
-                                startDate: state.startDate,
-                                readingTime: state.readingTime,
-                                context: context,
-                              ),
-                            )
-                          : const SizedBox(),
                       SizedBox(
                         height: (state.pages != null) ? 5 : 0,
                       ),


### PR DESCRIPTION
Work in progress for additional reading dates.

The main start date, reading date and custom reading time stay the same.

There is new TEXT column in the DB which is an aray of additonal reading dates.
One additional reading date is in text form like this (three values, separated by pipe character):

`iso8601string|iso8601string|integer`
first string is start date, second finish date, and the last number is custom reading time in milliseconds. The values can also be empty like:
`||`

<img width="300" alt="obraz" src="https://github.com/mateusz-bak/openreads-android/assets/32651935/e7a94c02-5c32-4b79-970c-bfdeb74f7abc">

<img width="300" alt="obraz" src="https://github.com/mateusz-bak/openreads-android/assets/32651935/ddabe412-7403-44a2-8897-9bfab6b39f1e">

