### PR TITLE
Filtering out already existing tags

### DIFF
--- a/lib/ui/add_book_screen/add_book_screen.dart
+++ b/lib/ui/add_book_screen/add_book_screen.dart
@@ -20,6 +20,7 @@ import 'package:openreads/main.dart';
 import 'package:openreads/model/book.dart';
 import 'package:openreads/ui/add_book_screen/widgets/cover_view_edit.dart';
 import 'package:openreads/ui/add_book_screen/widgets/widgets.dart';
+import 'package:openreads/ui/common/keyboard_dismissable.dart';
 
 class AddBookScreen extends StatefulWidget {
   const AddBookScreen({
@@ -321,256 +322,262 @@ class _AddBookScreenState extends State<AddBookScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(
-          widget.editingExistingBook
-              ? LocaleKeys.edit_book.tr()
-              : LocaleKeys.add_new_book.tr(),
-          style: const TextStyle(fontSize: 18),
+    return KeyboardDismissible(
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(
+            widget.editingExistingBook
+                ? LocaleKeys.edit_book.tr()
+                : LocaleKeys.add_new_book.tr(),
+            style: const TextStyle(fontSize: 18),
+          ),
+          actions: [
+            BlocBuilder<EditBookCubit, Book>(
+              builder: (context, state) {
+                return TextButton(
+                  onPressed: (state.id != null)
+                      ? () => _updateBook(state)
+                      : () => _saveBook(state),
+                  child: Text(
+                    LocaleKeys.save.tr(),
+                    style: const TextStyle(fontSize: 16),
+                  ),
+                );
+              },
+            )
+          ],
         ),
-        actions: [
-          BlocBuilder<EditBookCubit, Book>(
-            builder: (context, state) {
-              return TextButton(
-                onPressed: (state.id != null)
-                    ? () => _updateBook(state)
-                    : () => _saveBook(state),
-                child: Text(
-                  LocaleKeys.save.tr(),
-                  style: const TextStyle(fontSize: 16),
+        body: SafeArea(
+          child: SingleChildScrollView(
+            child: Column(
+              children: <Widget>[
+                _buildCover(),
+                const Padding(
+                  padding: EdgeInsets.all(10),
+                  child: Divider(),
                 ),
-              );
-            },
-          )
-        ],
-      ),
-      body: SafeArea(
-        child: SingleChildScrollView(
-          child: Column(
-            children: <Widget>[
-              _buildCover(),
-              const Padding(
-                padding: EdgeInsets.all(10),
-                child: Divider(),
-              ),
-              BookTextField(
-                controller: _titleCtrl,
-                hint: LocaleKeys.enter_title.tr(),
-                icon: Icons.book,
-                keyboardType: TextInputType.name,
-                autofocus:
-                    (widget.fromOpenLibrary || widget.editingExistingBook)
-                        ? false
-                        : true,
-                maxLines: 5,
-                maxLength: 255,
-                textCapitalization: TextCapitalization.sentences,
-              ),
-              const SizedBox(height: 10),
-              BookTextField(
-                controller: _subtitleCtrl,
-                hint: LocaleKeys.enter_subtitle.tr(),
-                icon: Icons.book,
-                keyboardType: TextInputType.name,
-                maxLines: 5,
-                maxLength: 255,
-                textCapitalization: TextCapitalization.sentences,
-              ),
-              const SizedBox(height: 10),
-              BookTextField(
-                controller: _authorCtrl,
-                hint: LocaleKeys.enter_author.tr(),
-                icon: Icons.person,
-                keyboardType: TextInputType.name,
-                maxLines: 5,
-                maxLength: 255,
-                textCapitalization: TextCapitalization.words,
-              ),
-              const Padding(
-                padding: EdgeInsets.all(10),
-                child: Divider(),
-              ),
-              BookStatusRow(
-                animDuration: _animDuration,
-                defaultHeight: defaultFormHeight,
-              ),
-              const SizedBox(height: 10),
-              BookRatingBar(animDuration: _animDuration),
-              BlocBuilder<EditBookCubit, Book>(
-                builder: (context, state) {
-                  return Column(
-                    children: [
-                      ...state.readings.asMap().entries.map(
-                        (entry) {
-                          return ReadingRow(
-                            index: entry.key,
-                            reading: entry.value,
+                BookTextField(
+                  controller: _titleCtrl,
+                  hint: LocaleKeys.enter_title.tr(),
+                  icon: Icons.book,
+                  keyboardType: TextInputType.name,
+                  autofocus:
+                      (widget.fromOpenLibrary || widget.editingExistingBook)
+                          ? false
+                          : true,
+                  maxLines: 5,
+                  maxLength: 255,
+                  textCapitalization: TextCapitalization.sentences,
+                ),
+                const SizedBox(height: 10),
+                BookTextField(
+                  controller: _subtitleCtrl,
+                  hint: LocaleKeys.enter_subtitle.tr(),
+                  icon: Icons.book,
+                  keyboardType: TextInputType.name,
+                  maxLines: 5,
+                  maxLength: 255,
+                  textCapitalization: TextCapitalization.sentences,
+                ),
+                const SizedBox(height: 10),
+                BookTextField(
+                  controller: _authorCtrl,
+                  hint: LocaleKeys.enter_author.tr(),
+                  icon: Icons.person,
+                  keyboardType: TextInputType.name,
+                  maxLines: 5,
+                  maxLength: 255,
+                  textCapitalization: TextCapitalization.words,
+                ),
+                const Padding(
+                  padding: EdgeInsets.all(10),
+                  child: Divider(),
+                ),
+                BookStatusRow(
+                  animDuration: _animDuration,
+                  defaultHeight: defaultFormHeight,
+                ),
+                const SizedBox(height: 10),
+                BookRatingBar(animDuration: _animDuration),
+                BlocBuilder<EditBookCubit, Book>(
+                  builder: (context, state) {
+                    return Column(
+                      children: [
+                        ...state.readings.asMap().entries.map(
+                          (entry) {
+                            return ReadingRow(
+                              index: entry.key,
+                              reading: entry.value,
+                            );
+                          },
+                        ),
+                      ],
+                    );
+                  },
+                ),
+                _buildAddNewReadingButton(context),
+                const Padding(
+                  padding: EdgeInsets.all(10),
+                  child: Divider(),
+                ),
+                BookTypeDropdown(
+                  bookTypes: bookTypes,
+                  changeBookType: _changeBookType,
+                ),
+                const SizedBox(height: 10),
+                Row(
+                  children: [
+                    Expanded(
+                      child: BookTextField(
+                        controller: _pagesCtrl,
+                        hint: LocaleKeys.enter_pages.tr(),
+                        icon: FontAwesomeIcons.solidFileLines,
+                        keyboardType: TextInputType.number,
+                        inputFormatters: <TextInputFormatter>[
+                          FilteringTextInputFormatter.digitsOnly
+                        ],
+                        maxLength: 10,
+                        padding: const EdgeInsets.fromLTRB(10, 0, 5, 0),
+                      ),
+                    ),
+                    Expanded(
+                      child: BookTextField(
+                        controller: _pubYearCtrl,
+                        hint: LocaleKeys.enter_publication_year.tr(),
+                        icon: FontAwesomeIcons.solidCalendar,
+                        keyboardType: TextInputType.number,
+                        inputFormatters: <TextInputFormatter>[
+                          FilteringTextInputFormatter.digitsOnly
+                        ],
+                        maxLength: 4,
+                        padding: const EdgeInsets.fromLTRB(5, 0, 10, 0),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 10),
+                BookTextField(
+                  controller: _descriptionCtrl,
+                  hint: LocaleKeys.enter_description.tr(),
+                  icon: FontAwesomeIcons.solidKeyboard,
+                  keyboardType: TextInputType.multiline,
+                  maxLength: 5000,
+                  hideCounter: false,
+                  maxLines: 15,
+                  textCapitalization: TextCapitalization.sentences,
+                ),
+                const SizedBox(height: 10),
+                BookTextField(
+                  controller: _isbnCtrl,
+                  hint: LocaleKeys.isbn.tr(),
+                  icon: FontAwesomeIcons.i,
+                  keyboardType: TextInputType.number,
+                  inputFormatters: <TextInputFormatter>[
+                    FilteringTextInputFormatter.digitsOnly
+                  ],
+                  maxLength: 20,
+                ),
+                const SizedBox(height: 10),
+                BookTextField(
+                  controller: _olidCtrl,
+                  hint: LocaleKeys.open_library_ID.tr(),
+                  icon: FontAwesomeIcons.o,
+                  keyboardType: TextInputType.text,
+                  maxLength: 20,
+                  textCapitalization: TextCapitalization.characters,
+                ),
+                const SizedBox(height: 10),
+                StreamBuilder<List<String>>(
+                  stream: bookCubit.tags,
+                  builder: (context, AsyncSnapshot<List<String>?> snapshot) {
+                    final book = context.read<EditBookCubit>().state;
+                    return TagsField(
+                      existingTags: _parseBookTags(book.tags),
+                      controller: _tagsCtrl,
+                      hint: LocaleKeys.enter_tags.tr(),
+                      icon: FontAwesomeIcons.tags,
+                      keyboardType: TextInputType.text,
+                      maxLength: 20,
+                      onSubmitted: (_) => _addNewTag(),
+                      onEditingComplete: () {},
+                      unselectTag: (tag) => _unselectTag(tag),
+                      allTags: snapshot.data,
+                    );
+                  },
+                ),
+                const Padding(
+                  padding: EdgeInsets.all(10),
+                  child: Divider(),
+                ),
+                BookTextField(
+                  controller: _myReviewCtrl,
+                  hint: LocaleKeys.my_review.tr(),
+                  icon: FontAwesomeIcons.solidKeyboard,
+                  keyboardType: TextInputType.multiline,
+                  maxLength: 5000,
+                  hideCounter: false,
+                  maxLines: 15,
+                  textCapitalization: TextCapitalization.sentences,
+                ),
+                const SizedBox(height: 10),
+                BookTextField(
+                  controller: _notesCtrl,
+                  hint: LocaleKeys.notes.tr(),
+                  icon: FontAwesomeIcons.noteSticky,
+                  keyboardType: TextInputType.multiline,
+                  maxLength: 5000,
+                  hideCounter: false,
+                  maxLines: 15,
+                  textCapitalization: TextCapitalization.sentences,
+                ),
+                const SizedBox(height: 30),
+                Row(
+                  children: [
+                    const SizedBox(width: 10),
+                    Expanded(
+                      flex: 10,
+                      child: FilledButton.tonal(
+                        onPressed: () => Navigator.pop(context),
+                        style: ButtonStyle(
+                          shape:
+                              MaterialStateProperty.all(RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(cornerRadius),
+                          )),
+                        ),
+                        child: const Center(
+                          child: Text("Cancel"),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      flex: 19,
+                      child: BlocBuilder<EditBookCubit, Book>(
+                        builder: (context, state) {
+                          return FilledButton(
+                            onPressed: (state.id != null)
+                                ? () => _updateBook(state)
+                                : () => _saveBook(state),
+                            style: ButtonStyle(
+                              shape: MaterialStateProperty.all(
+                                  RoundedRectangleBorder(
+                                borderRadius:
+                                    BorderRadius.circular(cornerRadius),
+                              )),
+                            ),
+                            child: const Center(
+                              child: Text("Save"),
+                            ),
                           );
                         },
                       ),
-                    ],
-                  );
-                },
-              ),
-              _buildAddNewReadingButton(context),
-              const Padding(
-                padding: EdgeInsets.all(10),
-                child: Divider(),
-              ),
-              BookTypeDropdown(
-                bookTypes: bookTypes,
-                changeBookType: _changeBookType,
-              ),
-              const SizedBox(height: 10),
-              Row(
-                children: [
-                  Expanded(
-                    child: BookTextField(
-                      controller: _pagesCtrl,
-                      hint: LocaleKeys.enter_pages.tr(),
-                      icon: FontAwesomeIcons.solidFileLines,
-                      keyboardType: TextInputType.number,
-                      inputFormatters: <TextInputFormatter>[
-                        FilteringTextInputFormatter.digitsOnly
-                      ],
-                      maxLength: 10,
-                      padding: const EdgeInsets.fromLTRB(10, 0, 5, 0),
                     ),
-                  ),
-                  Expanded(
-                    child: BookTextField(
-                      controller: _pubYearCtrl,
-                      hint: LocaleKeys.enter_publication_year.tr(),
-                      icon: FontAwesomeIcons.solidCalendar,
-                      keyboardType: TextInputType.number,
-                      inputFormatters: <TextInputFormatter>[
-                        FilteringTextInputFormatter.digitsOnly
-                      ],
-                      maxLength: 4,
-                      padding: const EdgeInsets.fromLTRB(5, 0, 10, 0),
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 10),
-              BookTextField(
-                controller: _descriptionCtrl,
-                hint: LocaleKeys.enter_description.tr(),
-                icon: FontAwesomeIcons.solidKeyboard,
-                keyboardType: TextInputType.multiline,
-                maxLength: 5000,
-                hideCounter: false,
-                maxLines: 15,
-                textCapitalization: TextCapitalization.sentences,
-              ),
-              const SizedBox(height: 10),
-              BookTextField(
-                controller: _isbnCtrl,
-                hint: LocaleKeys.isbn.tr(),
-                icon: FontAwesomeIcons.i,
-                keyboardType: TextInputType.number,
-                inputFormatters: <TextInputFormatter>[
-                  FilteringTextInputFormatter.digitsOnly
-                ],
-                maxLength: 20,
-              ),
-              const SizedBox(height: 10),
-              BookTextField(
-                controller: _olidCtrl,
-                hint: LocaleKeys.open_library_ID.tr(),
-                icon: FontAwesomeIcons.o,
-                keyboardType: TextInputType.text,
-                maxLength: 20,
-                textCapitalization: TextCapitalization.characters,
-              ),
-              const SizedBox(height: 10),
-              StreamBuilder<List<String>>(
-                stream: bookCubit.tags,
-                builder: (context, AsyncSnapshot<List<String>?> snapshot) {
-                  return TagsField(
-                    controller: _tagsCtrl,
-                    hint: LocaleKeys.enter_tags.tr(),
-                    icon: FontAwesomeIcons.tags,
-                    keyboardType: TextInputType.text,
-                    maxLength: 20,
-                    onSubmitted: (_) => _addNewTag(),
-                    onEditingComplete: () {},
-                    unselectTag: (tag) => _unselectTag(tag),
-                    allTags: snapshot.data,
-                  );
-                },
-              ),
-              const Padding(
-                padding: EdgeInsets.all(10),
-                child: Divider(),
-              ),
-              BookTextField(
-                controller: _myReviewCtrl,
-                hint: LocaleKeys.my_review.tr(),
-                icon: FontAwesomeIcons.solidKeyboard,
-                keyboardType: TextInputType.multiline,
-                maxLength: 5000,
-                hideCounter: false,
-                maxLines: 15,
-                textCapitalization: TextCapitalization.sentences,
-              ),
-              const SizedBox(height: 10),
-              BookTextField(
-                controller: _notesCtrl,
-                hint: LocaleKeys.notes.tr(),
-                icon: FontAwesomeIcons.noteSticky,
-                keyboardType: TextInputType.multiline,
-                maxLength: 5000,
-                hideCounter: false,
-                maxLines: 15,
-                textCapitalization: TextCapitalization.sentences,
-              ),
-              const SizedBox(height: 30),
-              Row(
-                children: [
-                  const SizedBox(width: 10),
-                  Expanded(
-                    flex: 10,
-                    child: FilledButton.tonal(
-                      onPressed: () => Navigator.pop(context),
-                      style: ButtonStyle(
-                        shape: MaterialStateProperty.all(RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(cornerRadius),
-                        )),
-                      ),
-                      child: const Center(
-                        child: Text("Cancel"),
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: 10),
-                  Expanded(
-                    flex: 19,
-                    child: BlocBuilder<EditBookCubit, Book>(
-                      builder: (context, state) {
-                        return FilledButton(
-                          onPressed: (state.id != null)
-                              ? () => _updateBook(state)
-                              : () => _saveBook(state),
-                          style: ButtonStyle(
-                            shape: MaterialStateProperty.all(
-                                RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(cornerRadius),
-                            )),
-                          ),
-                          child: const Center(
-                            child: Text("Save"),
-                          ),
-                        );
-                      },
-                    ),
-                  ),
-                  const SizedBox(width: 10),
-                ],
-              ),
-              const SizedBox(height: 50.0),
-            ],
+                    const SizedBox(width: 10),
+                  ],
+                ),
+                const SizedBox(height: 50.0),
+              ],
+            ),
           ),
         ),
       ),
@@ -599,5 +606,21 @@ class _AddBookScreenState extends State<AddBookScreen> {
         ),
       ),
     );
+  }
+
+  List<String> _parseBookTags(String? tags) {
+    if (tags == null) {
+      return [];
+    }
+    final List<String> parsedTags = List<String>.empty(growable: true);
+
+    for (String tag in tags.split('|||||')) {
+      if (!parsedTags.contains(tag)) {
+        parsedTags.add(tag);
+      }
+    }
+    parsedTags.sort((a, b) => a.compareTo(b));
+
+    return parsedTags;
   }
 }

--- a/lib/ui/add_book_screen/widgets/tags_text_field.dart
+++ b/lib/ui/add_book_screen/widgets/tags_text_field.dart
@@ -7,24 +7,24 @@ import 'package:openreads/logic/cubit/edit_book_cubit.dart';
 import 'package:openreads/model/book.dart';
 
 class TagsField extends StatelessWidget {
-  const TagsField({
-    super.key,
-    this.controller,
-    this.hint,
-    this.icon,
-    required this.keyboardType,
-    required this.maxLength,
-    this.inputFormatters,
-    this.autofocus = false,
-    this.maxLines = 1,
-    this.hideCounter = true,
-    this.textInputAction,
-    this.textCapitalization = TextCapitalization.none,
-    this.onSubmitted,
-    this.onEditingComplete,
-    this.unselectTag,
-    this.allTags,
-  });
+  const TagsField(
+      {super.key,
+      this.controller,
+      this.hint,
+      this.icon,
+      required this.keyboardType,
+      required this.maxLength,
+      this.inputFormatters,
+      this.autofocus = false,
+      this.maxLines = 1,
+      this.hideCounter = true,
+      this.textInputAction,
+      this.textCapitalization = TextCapitalization.none,
+      this.onSubmitted,
+      this.onEditingComplete,
+      this.unselectTag,
+      this.allTags,
+      required this.existingTags});
 
   final TextEditingController? controller;
   final String? hint;
@@ -39,7 +39,7 @@ class TagsField extends StatelessWidget {
   final TextCapitalization textCapitalization;
   final Function(String)? onSubmitted;
   final Function()? onEditingComplete;
-
+  final List<String> existingTags;
   final Function(String)? unselectTag;
   final List<String>? allTags;
 
@@ -100,6 +100,10 @@ class TagsField extends StatelessWidget {
             Scrollbar(
               child: TypeAheadField(
                 itemBuilder: (context, suggestion) {
+                  if (existingTags.contains(suggestion)) {
+                    return const SizedBox.shrink();
+                  }
+
                   return Container(
                     color: Theme.of(context).colorScheme.surfaceVariant,
                     child: ListTile(


### PR DESCRIPTION
I've made it possible to filter out already set tags in the book editing view. I did not get the chance to extensively test it, because the current version fails with this error upon adding or editing a book:

 `SqfliteDatabaseException (DatabaseException(Error Domain=FMDatabase Code=1 "table booksTable has no column named readings" UserInfo={NSLocalizedDescription=table booksTable has no column named readings}) sql 'INSERT INTO booksTable`

Can add a separate issue soon.