### PR TITLE
Fix it is/its typo in the welcome screen

### DIFF
--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -207,7 +207,7 @@
     "welcome_2_description_1": "Progress with your readings thanks to awesome and detailed statistics.",
     "welcome_2_description_2": "Challenge yourself to be a better reader.",
     "welcome_3_description_1": "Openreads is completely open source!",
-    "welcome_3_description_2": "It means that you can inspect the app's code on your own and contribute to it's development.",
+    "welcome_3_description_2": "It means that you can inspect the app's code on your own and contribute to its development.",
     "welcome_3_description_3": "As a bonus you get zero ads and absolutely no tracking!",
     "start_button": "START",
     "migration_v1_to_v2_1": "Your books are being migrated to the new version",


### PR DESCRIPTION
It should use a possessive form. Same issue as https://github.com/mateusz-bak/openreads/pull/144