### PR TITLE
feat: Allow for negative years

### DIFF
--- a/lib/logic/cubit/edit_book_cubit.dart
+++ b/lib/logic/cubit/edit_book_cubit.dart
@@ -81,7 +81,7 @@ class EditBookCubit extends Cubit<Book> {
   void setPublicationYear(String publicationYear) {
     final book = state.copyWith();
     book.publicationYear =
-        publicationYear.isEmpty ? null : int.parse(publicationYear);
+        publicationYear.isEmpty ? null : int.tryParse(publicationYear);
 
     emit(book);
   }

--- a/lib/ui/add_book_screen/add_book_screen.dart
+++ b/lib/ui/add_book_screen/add_book_screen.dart
@@ -556,9 +556,12 @@ class _AddBookScreenState extends State<AddBookScreen> {
                         icon: FontAwesomeIcons.solidCalendar,
                         keyboardType: TextInputType.number,
                         inputFormatters: <TextInputFormatter>[
-                          FilteringTextInputFormatter.digitsOnly
+                          // allow optional leading '-' for BCE years
+                          FilteringTextInputFormatter.allow(
+                              RegExp(r'^-?\d{0,4}')),
                         ],
-                        maxLength: 4,
+                        // allow space for a leading '-' (e.g. -500)
+                        maxLength: 5,
                         padding: const EdgeInsets.fromLTRB(5, 0, 10, 0),
                       ),
                     ),


### PR DESCRIPTION
Allow for negative years in publication date field, with a regexp allowing for a "-" in the beginning, and 0 to four digits.

While typing, the intial "-" is allowed before typing the other digits. If the data is sent withtout the digits (only a "-" as date), the controller applies tryParse which returns null in this case and therefore "-" cannot be saved as a date even if the input is possible first.